### PR TITLE
Bug fixes in Notebook plugin

### DIFF
--- a/podoc/markdown/_markdown.py
+++ b/podoc/markdown/_markdown.py
@@ -189,7 +189,10 @@ class ASTToMarkdown(TreeTransformer):
         # Otherwise we just concatenate the children.
         if node.children:
             child = node.children[0]
-            if isinstance(child, ASTNode) and child.is_block():
+            # TODO: improve this.
+            if (isinstance(child, ASTNode) and
+                (child.is_block() or
+                 child.get('_visit_meta', {}).get('is_block', None))):
                 delim = '\n\n'
         return delim.join(self.transform_children(node))
 

--- a/podoc/notebook/_notebook.py
+++ b/podoc/notebook/_notebook.py
@@ -146,6 +146,8 @@ class NotebookReader(object):
 
     def read_code(self, cell, cell_index=None):
         node = ASTNode('CodeCell')
+        # TODO: improve this.
+        node._visit_meta['is_block'] = True
         # The first child is the source.
         # NOTE: the language of the code block is the notebook's language.
         node.add_child(ASTNode('CodeBlock',

--- a/podoc/notebook/tests/test_notebook.py
+++ b/podoc/notebook/tests/test_notebook.py
@@ -44,7 +44,7 @@ def test_extract_output():
     assert data == data_expected
 
 
-def test_wrap_code_cells():
+def test_wrap_code_cells_1():
     # Test wrap_code_cells() with a single code cell.
     ast = ASTNode('root')
     ast.add_child(ASTNode('CodeBlock', lang='python', children=['']))
@@ -54,6 +54,36 @@ def test_wrap_code_cells():
 
     ast_expected = ASTNode('root')
     ast_expected.add_child(ASTNode('CodeCell', children=[ast.children[0]]))
+
+    assert_equal(ast_wrapped, ast_expected)
+
+
+def test_wrap_code_cells_2():
+    # Test wrap_code_cells() with two code cells.
+    ast = ASTNode('root')
+
+    cb0 = ASTNode('CodeBlock', lang='python', children=['a'])
+    cb1 = ASTNode('CodeBlock', lang='python', children=['b'])
+
+    ast.add_child(cb0)
+    ast.add_child(cb1)
+
+    ast.show()
+    ast_wrapped = wrap_code_cells(ast)
+    ast_wrapped.show()
+
+    ast_expected = ASTNode('root')
+
+    # First code cell.
+    code_cell0 = ASTNode('CodeCell')
+    code_cell0.add_child(cb0)
+    ast_expected.add_child(code_cell0)
+
+    # Second code cell.
+    code_cell1 = ASTNode('CodeCell')
+    code_cell1.add_child(cb1)
+    ast_expected.add_child(code_cell1)
+    ast_expected.show()
 
     assert_equal(ast_wrapped, ast_expected)
 


### PR DESCRIPTION
* Fix bug with consecutive code cells.
* Cleaner implementation of `wrap_code_cells()` and fix consecutive code cells.

reported by @basnijholt